### PR TITLE
[Ftx] Fix Derivative minimum amount

### DIFF
--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAdapters.java
@@ -164,7 +164,7 @@ public class FtxAdapters {
                 if (instrument instanceof FuturesContract) {
                   DerivativeMetaData futuresContractMetaData =
                       new DerivativeMetaData.Builder()
-                          .minimumAmount(ftxMarketDto.getMinProvideSize())
+                          .minimumAmount(ftxMarketDto.getSizeIncrement())
                           .amountStepSize(ftxMarketDto.getSizeIncrement())
                           .amountScale(ftxMarketDto.getSizeIncrement().scale())
                           .priceStepSize(ftxMarketDto.getPriceIncrement())


### PR DESCRIPTION
The minimum order amount is determined by the sizeIncrement. (https://docs.ftx.com/?javascript#get-markets)

minProvideSize is used for different purpose as explained here:

```
Minimum Size
Minimum BTC-PERP Trade Size:

The minimum provide (maker) size for BTC-Perp is 0.01, this only applies when you make more than 10 orders per hour smaller than 0.01. 

Limit orders sent that are larger than the market's quantity step but smaller than its minimum provide size are automatically turned into IOC orders.

This restriction is only applied at placement time, and only for the first 10 orders per hour (rolling). If a limit order is successfully placed, and then gets partially filled such that some amount under the minimum provide size is left, then that order remains out; the rest doesn't get cancelled.

If an account has a position whose size is smaller than the minimum provide size, reduce-only limit orders will still be rounded down to that size and successfully placed.

```
link: https://help.ftx.com/hc/en-us/articles/360024780511-Complete-Futures-Specs)