### PR TITLE
fix binance leverage deserialization issue

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesInitialLeverage.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesInitialLeverage.java
@@ -6,15 +6,12 @@ import java.math.BigDecimal;
 
 public final class BinanceFuturesInitialLeverage {
     public final int leverage;
-    public final BigDecimal maxNotionalValue;
     public final String symbol;
 
     public BinanceFuturesInitialLeverage(
             @JsonProperty("leverage") int leverage,
-            @JsonProperty("maxNotionalValue") BigDecimal maxNotionalValue,
             @JsonProperty("symbol") String symbol) {
         this.leverage = leverage;
-        this.maxNotionalValue = maxNotionalValue;
         this.symbol = symbol;
     }
 }


### PR DESCRIPTION
while working on a testnet discovered that **maxNotionalValue** sent from Binance sometimes contains "INF" string that leads to deserialisation exceptions.
quick fix will be to remove it from DTO - not in use.