### PR TITLE
Binance Futures APIs: position risk, leverage

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceMarginType.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/account/BinanceMarginType.java
@@ -9,7 +9,12 @@ public enum BinanceMarginType {
     @JsonCreator
     public static BinanceMarginType getBinanceMarginType(String s) {
         try {
-            return BinanceMarginType.valueOf(s);
+            if (s.equalsIgnoreCase("isolated")) {
+                return BinanceMarginType.ISOLATED;
+            } else if (s.equalsIgnoreCase("cross")) {
+                return BinanceMarginType.CROSSED;
+            }
+            return BinanceMarginType.valueOf(s.toUpperCase());
         } catch (Exception e) {
             throw new RuntimeException("Unknown margin type " + s + ".");
         }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapter.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapter.java
@@ -83,7 +83,7 @@ public class BinanceFuturesAdapter {
         switch (positionSide) {
             case LONG: return OpenPosition.Type.LONG;
             case SHORT: return OpenPosition.Type.SHORT;
-            default: return positionAmt.compareTo(BigDecimal.ZERO) > 0 ? OpenPosition.Type.LONG : OpenPosition.Type.SHORT;
+            default: return positionAmt.signum() > 0 ? OpenPosition.Type.LONG : OpenPosition.Type.SHORT;
         }
     }
 

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAuthenticated.java
@@ -93,10 +93,10 @@ public interface BinanceFuturesAuthenticated extends BinanceAuthenticated {
      * created time + 7 days < current time
      *
      * @param symbol required
-     * @param limit optional, default 500; max 1000.
+     * @param orderId optional, If is set, it will get orders >= that orderId. Otherwise most recent orders are returned.
      * @param startTime optional
      * @param endTime optional
-     * @param fromId optional, If is set, it will get orders >= that orderId. Otherwise most recent orders are returned.
+     * @param limit optional, default 500; max 1000.
      * @param recvWindow optional
      * @param timestamp required
      *
@@ -106,10 +106,10 @@ public interface BinanceFuturesAuthenticated extends BinanceAuthenticated {
      */
     List<BinanceFuturesOrder> futuresAllOrders(
             @QueryParam("symbol") String symbol,
-            @QueryParam("limit") Integer limit,
+            @QueryParam("orderId") Long orderId,
             @QueryParam("startTime") Long startTime,
             @QueryParam("endTime") Long endTime,
-            @QueryParam("fromId") Long fromId,
+            @QueryParam("limit") Integer limit,
             @QueryParam("recvWindow") Long recvWindow,
             @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
             @HeaderParam(X_MBX_APIKEY) String apiKey,

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/BinanceFuturesAuthenticated.java
@@ -8,10 +8,7 @@ import org.knowm.xchange.binance.dto.marketdata.BinanceAggTrades;
 import org.knowm.xchange.binance.dto.marketdata.BinanceOrderbook;
 import org.knowm.xchange.binance.dto.marketdata.BinanceTicker24h;
 import org.knowm.xchange.binance.dto.trade.*;
-import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesAccountInformation;
-import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesIncomeHistoryRecord;
-import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesInitialLeverage;
-import org.knowm.xchange.binance.futures.dto.account.BinanceUserCommissionRate;
+import org.knowm.xchange.binance.futures.dto.account.*;
 import org.knowm.xchange.binance.futures.dto.meta.BinanceFuturesExchangeInfo;
 import org.knowm.xchange.binance.futures.dto.trade.*;
 import si.mazi.rescu.ParamsDigest;
@@ -464,6 +461,42 @@ public interface BinanceFuturesAuthenticated extends BinanceAuthenticated {
             @QueryParam("startTime") Long startTime,
             @QueryParam("endTime") Long endTime,
             @QueryParam("limit") Integer limit,
+            @QueryParam("recvWindow") Long recvWindow,
+            @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
+            @HeaderParam(X_MBX_APIKEY) String apiKey,
+            @QueryParam(SIGNATURE) ParamsDigest signature)
+            throws IOException, BinanceException;
+
+    /**
+     * Get leverage brackets
+     *
+     * @param symbol optional
+     *
+     * @throws IOException
+     * @throws BinanceException
+     */
+    @GET
+    @Path("/fapi/v1/leverageBracket")
+    List<BinanceFuturesLeverageBrackets> getLeverageBrackets(
+            @QueryParam("symbol") String symbol,
+            @QueryParam("recvWindow") Long recvWindow,
+            @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
+            @HeaderParam(X_MBX_APIKEY) String apiKey,
+            @QueryParam(SIGNATURE) ParamsDigest signature)
+            throws IOException, BinanceException;
+
+    /**
+     * Get current position information.
+     *
+     * @param symbol optional
+     *
+     * @throws IOException
+     * @throws BinanceException
+     */
+    @GET
+    @Path("/fapi/v1/positionRisk")
+    List<BinanceFuturesPositionInformation> getPositionInformation(
+            @QueryParam("symbol") String symbol,
             @QueryParam("recvWindow") Long recvWindow,
             @QueryParam("timestamp") SynchronizedValueFactory<Long> timestamp,
             @HeaderParam(X_MBX_APIKEY) String apiKey,

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesLeverageBracket.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesLeverageBracket.java
@@ -1,0 +1,31 @@
+package org.knowm.xchange.binance.futures.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public class BinanceFuturesLeverageBracket {
+
+    public final int bracket;
+    public final int initialLeverage;
+    public final BigDecimal notionalCap;
+    public final BigDecimal notionalFloor;
+    public final BigDecimal maintMarginRatio;
+    public final BigDecimal cum;
+
+    public BinanceFuturesLeverageBracket(
+            @JsonProperty("leverage") int bracket,
+            @JsonProperty("initialLeverage") int initialLeverage,
+            @JsonProperty("notionalCap") BigDecimal notionalCap,
+            @JsonProperty("notionalFloor") BigDecimal notionalFloor,
+            @JsonProperty("maintMarginRatio") BigDecimal maintMarginRatio,
+            @JsonProperty("cum") BigDecimal cum) {
+        this.bracket = bracket;
+        this.initialLeverage = initialLeverage;
+        this.notionalCap = notionalCap;
+        this.notionalFloor = notionalFloor;
+        this.maintMarginRatio = maintMarginRatio;
+        this.cum = cum;
+    }
+}
+

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesLeverageBrackets.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesLeverageBrackets.java
@@ -1,0 +1,17 @@
+package org.knowm.xchange.binance.futures.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class BinanceFuturesLeverageBrackets {
+    public final String symbol;
+    public final List<BinanceFuturesLeverageBracket> brackets;
+
+    public BinanceFuturesLeverageBrackets(
+            @JsonProperty("symbol") String symbol,
+            @JsonProperty("brackets") List<BinanceFuturesLeverageBracket> brackets) {
+        this.symbol = symbol;
+        this.brackets = brackets;
+    }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesPositionInformation.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/dto/account/BinanceFuturesPositionInformation.java
@@ -1,0 +1,56 @@
+package org.knowm.xchange.binance.futures.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.binance.dto.account.BinanceMarginType;
+import org.knowm.xchange.binance.futures.dto.trade.PositionSide;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+
+public class BinanceFuturesPositionInformation {
+    public final String symbol;
+    public final BigDecimal positionAmt;
+    public final BigDecimal entryPrice;
+    public final BigDecimal markPrice;
+    public final BigDecimal unRealizedProfit;
+    public final BigDecimal liquidationPrice;
+    public final BigDecimal leverage;
+    public final BinanceMarginType marginType;
+    public final BigDecimal isolatedMargin;
+    public final boolean isAutoAddMargin;
+    public final PositionSide positionSide;
+    public final BigDecimal notional;
+    public final BigDecimal isolatedWallet;
+    public final long updateTime;
+
+    public BinanceFuturesPositionInformation(
+            @JsonProperty("symbol") String symbol,
+            @JsonProperty("positionAmt") BigDecimal positionAmt,
+            @JsonProperty("entryPrice") BigDecimal entryPrice,
+            @JsonProperty("markPrice") BigDecimal markPrice,
+            @JsonProperty("unRealizedProfit") BigDecimal unRealizedProfit,
+            @JsonProperty("liquidationPrice") BigDecimal liquidationPrice,
+            @JsonProperty("leverage") BigDecimal leverage,
+            @JsonProperty("marginType") BinanceMarginType marginType,
+            @JsonProperty("isolatedMargin") BigDecimal isolatedMargin,
+            @JsonProperty("isAutoAddMargin") boolean isAutoAddMargin,
+            @JsonProperty("positionSide") PositionSide positionSide,
+            @JsonProperty("notional") BigDecimal notional,
+            @JsonProperty("isolatedWallet") BigDecimal isolatedWallet,
+            @JsonProperty("updateTime") long updateTime) {
+        this.symbol = symbol;
+        this.positionAmt = positionAmt;
+        this.entryPrice = entryPrice;
+        this.markPrice = markPrice;
+        this.unRealizedProfit = unRealizedProfit;
+        this.liquidationPrice = liquidationPrice;
+        this.leverage = leverage;
+        this.marginType = marginType;
+        this.isolatedMargin = isolatedMargin;
+        this.isAutoAddMargin = isAutoAddMargin;
+        this.positionSide = positionSide;
+        this.notional = notional;
+        this.isolatedWallet = isolatedWallet;
+        this.updateTime = updateTime;
+    }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/service/BinanceFuturesAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/service/BinanceFuturesAccountService.java
@@ -7,9 +7,7 @@ import org.knowm.xchange.binance.BinanceExchange;
 import org.knowm.xchange.binance.dto.BinanceException;
 import org.knowm.xchange.binance.futures.BinanceFuturesAdapter;
 import org.knowm.xchange.binance.futures.BinanceFuturesAuthenticated;
-import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesAccountInformation;
-import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesIncomeHistoryRecord;
-import org.knowm.xchange.binance.futures.dto.account.BinanceUserCommissionRate;
+import org.knowm.xchange.binance.futures.dto.account.*;
 import org.knowm.xchange.binance.service.BinanceAccountService;
 import org.knowm.xchange.binance.service.account.params.BinanceAccountMarginParams;
 import org.knowm.xchange.binance.service.account.params.BinanceAccountPositionMarginParams;
@@ -178,6 +176,39 @@ public class BinanceFuturesAccountService extends BinanceAccountService {
         } catch (BinanceException e) {
             throw BinanceErrorAdapter.adapt(e);
         }
+    }
 
+    public List<BinanceFuturesLeverageBrackets> getLeverageBrackets(CurrencyPair currencyPair) throws IOException {
+        try {
+            return decorateApiCall(
+                    () -> binanceFutures.getLeverageBrackets(
+                            Optional.ofNullable(currencyPair).map(BinanceAdapters::toSymbol).orElse(null),
+                            getRecvWindow(),
+                            getTimestampFactory(),
+                            apiKey,
+                            signatureCreator))
+                    .withRetry(retry("getLeverageBrackets"))
+                    .withRateLimiter(rateLimiter(REQUEST_WEIGHT_RATE_LIMITER))
+                    .call();
+        } catch (BinanceException e) {
+            throw BinanceErrorAdapter.adapt(e);
+        }
+    }
+
+    public List<BinanceFuturesPositionInformation> getPositionInformation(CurrencyPair currencyPair) throws IOException {
+        try {
+            return decorateApiCall(
+                    () -> binanceFutures.getPositionInformation(
+                            Optional.ofNullable(currencyPair).map(BinanceAdapters::toSymbol).orElse(null),
+                            getRecvWindow(),
+                            getTimestampFactory(),
+                            apiKey,
+                            signatureCreator))
+                    .withRetry(retry("getPositionInformation"))
+                    .withRateLimiter(rateLimiter(REQUEST_WEIGHT_RATE_LIMITER), 5)
+                    .call();
+        } catch (BinanceException e) {
+            throw BinanceErrorAdapter.adapt(e);
+        }
     }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/service/BinanceFuturesTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/futures/service/BinanceFuturesTradeService.java
@@ -307,14 +307,14 @@ public class BinanceFuturesTradeService extends BinanceTradeService {
                 .call();
     }
 
-    public List<BinanceFuturesOrder> futuresAllOrders(CurrencyPair pair, Integer limit, Long startTime, Long endTime, Long fromId) throws BinanceException, IOException {
+    public List<BinanceFuturesOrder> futuresAllOrders(CurrencyPair pair, Long orderId, Long startTime, Long endTime, Integer limit) throws BinanceException, IOException {
         return decorateApiCall(() ->
                 ((BinanceFuturesAuthenticated)binance).futuresAllOrders(
                         Optional.ofNullable(pair).map(BinanceAdapters::toSymbol).orElse(null),
-                        limit,
+                        orderId,
                         startTime,
                         endTime,
-                        fromId,
+                        limit,
                         getRecvWindow(),
                         getTimestampFactory(),
                         apiKey,

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/dto/account/BinanceMarginTypeTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/dto/account/BinanceMarginTypeTest.java
@@ -1,0 +1,32 @@
+package org.knowm.xchange.binance.dto.account;
+
+import org.junit.Test;
+import org.knowm.xchange.utils.ObjectMapperHelper;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class BinanceMarginTypeTest {
+
+    @Test
+    public void createFromLowercase() throws IOException {
+        String s = ObjectMapperHelper.toJSON(BinanceMarginType.ISOLATED);
+        assertThat(ObjectMapperHelper.readValue(s.toLowerCase(), BinanceMarginType.class)).isEqualTo(BinanceMarginType.ISOLATED);
+    }
+
+    @Test
+    public void createFromUppercase() throws IOException {
+        assertThat(ObjectMapperHelper.viaJSON(BinanceMarginType.CROSSED)).isEqualTo(BinanceMarginType.CROSSED);
+    }
+
+    @Test
+    public void createFromBinanceDevsCannotArrangeValueCase() {
+        assertThat(BinanceMarginType.getBinanceMarginType("isolated")).isEqualTo(BinanceMarginType.ISOLATED);
+    }
+
+    @Test
+    public void createFromBinanceDevsCannotArrangeNamingConventionsCase() {
+        assertThat(BinanceMarginType.getBinanceMarginType   ("cross")).isEqualTo(BinanceMarginType.CROSSED);
+    }
+}

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapterTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapterTest.java
@@ -1,0 +1,35 @@
+package org.knowm.xchange.binance.futures;
+
+import org.junit.Test;
+import org.knowm.xchange.binance.futures.dto.trade.PositionSide;
+import org.knowm.xchange.dto.account.OpenPosition;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.knowm.xchange.binance.futures.BinanceFuturesAdapter.adaptPositionType;
+
+public class BinanceFuturesAdapterTest {
+
+    @Test
+    public void testAdaptPositionType1() {
+        assertThat(adaptPositionType(PositionSide.LONG, BigDecimal.ONE)).isEqualTo(OpenPosition.Type.LONG);
+    }
+    @Test
+    public void testAdaptPositionType2() {
+        assertThat(adaptPositionType(PositionSide.SHORT, BigDecimal.ONE)).isEqualTo(OpenPosition.Type.SHORT);
+    }
+    @Test
+    public void testAdaptPositionType3() {
+        assertThat(adaptPositionType(PositionSide.BOTH, BigDecimal.ONE)).isEqualTo(OpenPosition.Type.LONG);
+    }
+    @Test
+    public void testAdaptPositionType4() {
+        assertThat(adaptPositionType(PositionSide.BOTH, BigDecimal.ONE.negate())).isEqualTo(OpenPosition.Type.SHORT);
+    }
+    @Test
+    public void testAdaptPositionType5() {
+        //noinspection ConstantConditions
+        assertThat(adaptPositionType(null, null)).isNull();
+    }
+}


### PR DESCRIPTION
Added Binance Futures APIs in order to calculate marginRatio properly:
- position risk api
- leverage brackets api


Fixed allOrders API