### PR TITLE
Maksym/margin info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -506,6 +506,8 @@
           <skipTests>${skipIntegrationTests}</skipTests>
           <includes>
             <include>**/*Integration.java</include>
+            <include>**/*IntegrationTest.java</include>
+            <include>**/*Sample.java</include>
           </includes>
         </configuration>
       </plugin>

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceExchange.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Map;
 import org.knowm.xchange.BaseExchange;
+import org.knowm.xchange.ExchangeSharedParameters;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.binance.dto.account.AssetDetail;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.BinanceExchangeInfo;
@@ -23,9 +24,6 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.AuthUtils;
 import si.mazi.rescu.SynchronizedValueFactory;
 
-import static org.knowm.xchange.binance.BinanceExchange.Parameters.PARAM_SANDBOX_SSL_URI;
-import static org.knowm.xchange.binance.BinanceExchange.Parameters.PARAM_USE_SANDBOX;
-
 public class BinanceExchange extends BaseExchange {
 
   public static final String EXCHANGE_TYPE_MARGIN = "BinanceMarginExchange";
@@ -39,9 +37,6 @@ public class BinanceExchange extends BaseExchange {
 
   @Override
   protected void initServices() {
-
-    concludeHostParams(exchangeSpecification);
-
     if (EXCHANGE_TYPE_MARGIN.equals(exchangeSpecification.getExchangeSpecificParametersItem(EXCHANGE_TYPE))) {
       this.binance = ExchangeRestProxyBuilder.forInterface(
               BinanceMarginAuthenticated.class, getExchangeSpecification())
@@ -95,18 +90,11 @@ public class BinanceExchange extends BaseExchange {
     spec.setExchangeName("Binance");
     spec.setExchangeDescription("Binance Exchange.");
 
-    spec.setExchangeSpecificParametersItem(PARAM_USE_SANDBOX, false);
-    spec.setExchangeSpecificParametersItem(PARAM_SANDBOX_SSL_URI, "https://testnet.binance.vision");
+    spec.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_USE_SANDBOX, false);
+    spec.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_SANDBOX_SSL_URI, "https://testnet.binance.vision");
 
     AuthUtils.setApiAndSecretKey(spec, "binance");
     return spec;
-  }
-
-  @Override
-  public void applySpecification(ExchangeSpecification exchangeSpecification) {
-    super.applySpecification(exchangeSpecification);
-
-    concludeHostParams(exchangeSpecification);
   }
 
   public BinanceExchangeInfo getExchangeInfo() {
@@ -215,19 +203,4 @@ public class BinanceExchange extends BaseExchange {
     return new BigDecimal(value).stripTrailingZeros().scale();
   }
 
-  /** Adjust host parameters depending on exchange specific parameters */
-  protected static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
-
-    if (exchangeSpecification.getExchangeSpecificParameters() != null) {
-      final boolean useSandbox = exchangeSpecification.getExchangeSpecificParametersItem(PARAM_USE_SANDBOX).equals(true);
-      if (useSandbox) {
-        exchangeSpecification.setSslUri((String) exchangeSpecification.getExchangeSpecificParametersItem(PARAM_SANDBOX_SSL_URI));
-      }
-    }
-  }
-
-  public static final class Parameters {
-    public static final String PARAM_USE_SANDBOX = "Use_Sandbox";
-    public static final String PARAM_SANDBOX_SSL_URI = "SandboxSslUri";
-  }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceFuturesExchange.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceFuturesExchange.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.binance;
 
+import org.knowm.xchange.ExchangeSharedParameters;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.binance.dto.meta.exchangeinfo.Filter;
 import org.knowm.xchange.binance.futures.BinanceFuturesAuthenticated;
@@ -21,16 +22,10 @@ import si.mazi.rescu.SynchronizedValueFactory;
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static org.knowm.xchange.binance.BinanceExchange.Parameters.PARAM_USE_SANDBOX;
-import static org.knowm.xchange.binance.BinanceExchange.Parameters.PARAM_SANDBOX_SSL_URI;
-
 public class BinanceFuturesExchange extends BinanceExchange {
 
   @Override
   protected void initServices() {
-
-    concludeHostParams(exchangeSpecification);
-
     this.binance = ExchangeRestProxyBuilder.forInterface(
                     BinanceFuturesAuthenticated.class, getExchangeSpecification())
             .build();
@@ -59,8 +54,8 @@ public class BinanceFuturesExchange extends BinanceExchange {
     spec.setExchangeName("Binance Futures");
     spec.setExchangeDescription("Binance Futures Exchange.");
 
-    spec.setExchangeSpecificParametersItem(PARAM_USE_SANDBOX, false);
-    spec.setExchangeSpecificParametersItem(PARAM_SANDBOX_SSL_URI, "https://testnet.binancefuture.com/");
+    spec.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_USE_SANDBOX, false);
+    spec.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_SANDBOX_SSL_URI, "https://testnet.binancefuture.com/");
 
     AuthUtils.setApiAndSecretKey(spec, "binance");
     return spec;

--- a/xchange-binance/src/test/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapterTest.java
+++ b/xchange-binance/src/test/java/org/knowm/xchange/binance/futures/BinanceFuturesAdapterTest.java
@@ -1,10 +1,16 @@
 package org.knowm.xchange.binance.futures;
 
 import org.junit.Test;
+import org.knowm.xchange.binance.futures.dto.account.BinanceFuturesAccountInformation;
 import org.knowm.xchange.binance.futures.dto.trade.PositionSide;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.AccountMargin;
 import org.knowm.xchange.dto.account.OpenPosition;
+import org.knowm.xchange.dto.account.Wallet;
 
 import java.math.BigDecimal;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.knowm.xchange.binance.futures.BinanceFuturesAdapter.adaptPositionType;
@@ -31,5 +37,34 @@ public class BinanceFuturesAdapterTest {
     public void testAdaptPositionType5() {
         //noinspection ConstantConditions
         assertThat(adaptPositionType(null, null)).isNull();
+    }
+
+    @Test
+    public void testAdaptAccountInfo_wallet() {
+        BigDecimal mb = BigDecimal.TEN;
+        BigDecimal pnl = BigDecimal.ONE;
+        AccountInfo accountInfo = BinanceFuturesAdapter.adaptAccountInfo(new BinanceFuturesAccountInformation(0, true, true, true, 0, null, null, null, pnl, mb, null, null, null, null, null, null, null, null));
+
+        Optional<AccountMargin> margin = accountInfo.getAccountMargin();
+        assertThat(margin).isPresent();
+        assertThat(margin.get().getCurrency()).isEqualTo(Currency.USDT);
+        assertThat(margin.get().getMarginBalance()).isEqualTo(mb);
+        assertThat(margin.get().getUnrealizedProfit()).isEqualTo(pnl);
+    }
+
+    @Test
+    public void testAdaptAccountInfo_positions_null() {
+        AccountInfo accountInfo = BinanceFuturesAdapter.adaptAccountInfo(new BinanceFuturesAccountInformation(0, true, true, true, 0, null, null, null, null, null, null, null, null, null, null, null, null, null));
+
+        assertThat(accountInfo.getOpenPositions().size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAdaptAccountInfo_balances_null() {
+        AccountInfo accountInfo = BinanceFuturesAdapter.adaptAccountInfo(new BinanceFuturesAccountInformation(0, true, true, true, 0, null, null, null, null, null, null, null, null, null, null, null, null, null));
+
+        assertThat(accountInfo.getWallets().size()).isEqualTo(1);
+        Wallet wallet = accountInfo.getWallet();
+        assertThat(wallet.getBalances().size()).isEqualTo(0);
     }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSharedParameters.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSharedParameters.java
@@ -1,0 +1,7 @@
+package org.knowm.xchange;
+
+public class ExchangeSharedParameters {
+    public static final String PARAM_USE_SANDBOX = "UseSandbox";
+    public static final String PARAM_SANDBOX_SSL_URI = "SandboxSslUri";
+    public static final String PARAM_SANDBOX_STREAMING_URI = "SandboxStreamingSslUri";
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -30,6 +30,7 @@ public class ExchangeSpecification {
   private Integer proxyPort;
   private int httpConnTimeout = 0; // default rescu configuration will be used if value not changed
   private int httpReadTimeout = 0; // default rescu configuration will be used if value not changed
+  private String streamingUri;
   private ResilienceSpecification resilience = new ResilienceSpecification();
   private String metaDataJsonFileOverride = null;
   private boolean shouldLoadRemoteMetaData = true; // default value
@@ -473,6 +474,22 @@ public class ExchangeSpecification {
   public void setShouldLoadRemoteMetaData(boolean shouldLoadRemoteMetaData) {
 
     this.shouldLoadRemoteMetaData = shouldLoadRemoteMetaData;
+  }
+
+  /**
+   * uri used for streaming
+   * @return uri
+   */
+  public String getStreamingUri() {
+    return streamingUri;
+  }
+
+  /**
+   * uri used for streaming
+   * @param streamingUri uri
+   */
+  public void setStreamingUri(String streamingUri) {
+    this.streamingUri = streamingUri;
   }
 
   public static class ResilienceSpecification {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountMargin.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/AccountMargin.java
@@ -1,0 +1,88 @@
+package org.knowm.xchange.dto.account;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
+import org.knowm.xchange.currency.Currency;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+@JsonDeserialize(builder = AccountMargin.Builder.class)
+public class AccountMargin {
+    /** margin currency **/
+    private final Currency currency;
+    /** Current margin balance */
+    private final BigDecimal marginBalance;
+    /** Current PNL */
+    private final BigDecimal unrealizedProfit;
+
+    public AccountMargin(Currency currency, BigDecimal marginBalance, BigDecimal unrealizedProfit) {
+        this.currency = currency;
+        this.marginBalance = marginBalance;
+        this.unrealizedProfit = unrealizedProfit;
+    }
+
+    public Currency getCurrency() {
+        return currency;
+    }
+
+    public BigDecimal getMarginBalance() {
+        return marginBalance;
+    }
+
+    public BigDecimal getUnrealizedProfit() {
+        return unrealizedProfit;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AccountMargin that = (AccountMargin) o;
+        return Objects.equals(currency, that.currency) &&
+                Objects.equals(marginBalance, that.marginBalance) &&
+                Objects.equals(unrealizedProfit, that.unrealizedProfit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currency, marginBalance, unrealizedProfit);
+    }
+
+    @Override
+    public String toString() {
+        return "AccountMargin{" +
+                "currency=" + currency +
+                ", marginBalance=" + marginBalance +
+                ", unrealizedProfit=" + unrealizedProfit +
+                '}';
+    }
+
+    @JsonPOJOBuilder(withPrefix = "")
+    public static final class Builder {
+        private Currency currency;
+        private BigDecimal marginBalance;
+        private BigDecimal unrealizedProfit;
+
+        public Builder() {}
+
+        public Builder currency(Currency currency) {
+            this.currency = currency;
+            return this;
+        }
+
+        public Builder marginBalance(BigDecimal marginBalance) {
+            this.marginBalance = marginBalance;
+            return this;
+        }
+
+        public Builder unrealizedProfit(BigDecimal unrealizedProfit) {
+            this.unrealizedProfit = unrealizedProfit;
+            return this;
+        }
+
+        public AccountMargin build() {
+            return new AccountMargin(currency, marginBalance, unrealizedProfit);
+        }
+    }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/account/OpenPosition.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/account/OpenPosition.java
@@ -21,33 +21,41 @@ public class OpenPosition implements Serializable {
   private final BigDecimal price;
   /** Current mark price for position's instrument */
   private final BigDecimal markPrice;
+  /** Liquidation price */
+  private final BigDecimal liquidationPrice;
   /** Current initial leverage */
   private final BigDecimal leverage;
   /** Maintenance Margin / Margin Balance. Position will be liquidated once Margin Ratio reaches 1 */
   private final BigDecimal marginRatio;
+  /** unrealized profit */
+  private final BigDecimal unrealizedProfit;
   /** The time the position was valid on the exchange server */
   private final Date timestamp;
 
   public OpenPosition(Instrument instrument, Type type, BigDecimal size, BigDecimal price) {
-    this(instrument, type, size, price, null, null, null, null);
+    this(instrument, type, size, price, null, null, null, null, null, null);
   }
 
   private OpenPosition(
-      Instrument instrument,
-      Type type,
-      BigDecimal size,
-      BigDecimal price,
-      BigDecimal markPrice,
-      BigDecimal leverage,
-      BigDecimal marginRatio,
-      Date timestamp) {
+          Instrument instrument,
+          Type type,
+          BigDecimal size,
+          BigDecimal price,
+          BigDecimal markPrice,
+          BigDecimal liquidationPrice,
+          BigDecimal leverage,
+          BigDecimal marginRatio,
+          BigDecimal unrealizedProfit,
+          Date timestamp) {
     this.instrument = instrument;
     this.type = type;
     this.size = size;
     this.price = price;
     this.markPrice = markPrice;
+    this.liquidationPrice = liquidationPrice;
     this.leverage = leverage;
     this.marginRatio = marginRatio;
+    this.unrealizedProfit = unrealizedProfit;
     this.timestamp = timestamp;
   }
 
@@ -71,12 +79,20 @@ public class OpenPosition implements Serializable {
     return markPrice;
   }
 
+  public BigDecimal getLiquidationPrice() {
+    return liquidationPrice;
+  }
+
   public BigDecimal getLeverage() {
     return leverage;
   }
 
   public BigDecimal getMarginRatio() {
     return marginRatio;
+  }
+
+  public BigDecimal getUnrealizedProfit() {
+    return unrealizedProfit;
   }
 
   public Date getTimestamp() {
@@ -87,47 +103,43 @@ public class OpenPosition implements Serializable {
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    OpenPosition that = (OpenPosition) o;
-    return Objects.equals(instrument, that.instrument)
-        && type == that.type
-        && Objects.equals(size, that.size)
-        && Objects.equals(price, that.price)
-        && Objects.equals(markPrice, that.markPrice)
-        && Objects.equals(leverage, that.leverage)
-        && Objects.equals(marginRatio, that.marginRatio)
-        && Objects.equals(timestamp, that.timestamp);
+    OpenPosition position = (OpenPosition) o;
+    return Objects.equals(instrument, position.instrument) &&
+            type == position.type &&
+            Objects.equals(size, position.size) &&
+            Objects.equals(price, position.price) &&
+            Objects.equals(markPrice, position.markPrice) &&
+            Objects.equals(liquidationPrice, position.liquidationPrice) &&
+            Objects.equals(leverage, position.leverage) &&
+            Objects.equals(marginRatio, position.marginRatio) &&
+            Objects.equals(unrealizedProfit, position.unrealizedProfit) &&
+            Objects.equals(timestamp, position.timestamp);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(instrument, type, size, price, markPrice, leverage, marginRatio, timestamp);
+    return Objects.hash(instrument, type, size, price, markPrice, liquidationPrice, leverage, marginRatio, unrealizedProfit, timestamp);
   }
 
   @Override
   public String toString() {
-    return "OpenPosition{"
-        + "instrument="
-        + instrument
-        + ", type="
-        + type
-        + ", size="
-        + size
-        + ", price="
-        + price
-        + ", markPrice="
-        + markPrice
-        + ", leverage="
-        + leverage
-        + ", marginRatio="
-        + marginRatio
-        + ", timestamp="
-        + timestamp
-        + '}';
+    return "OpenPosition{" +
+            "instrument=" + instrument +
+            ", type=" + type +
+            ", size=" + size +
+            ", price=" + price +
+            ", markPrice=" + markPrice +
+            ", liquidationPrice=" + liquidationPrice +
+            ", leverage=" + leverage +
+            ", marginRatio=" + marginRatio +
+            ", unrealizedProfit=" + unrealizedProfit +
+            ", timestamp=" + timestamp +
+            '}';
   }
 
   public enum Type {
     LONG,
-    SHORT;
+    SHORT
   }
 
   @JsonPOJOBuilder(withPrefix = "")
@@ -137,20 +149,24 @@ public class OpenPosition implements Serializable {
     private BigDecimal size;
     private BigDecimal price;
     private BigDecimal markPrice;
+    private BigDecimal liquidationPrice;
     private BigDecimal leverage;
     private BigDecimal marginRatio;
+    private BigDecimal unrealizedProfit;
     private Date timestamp;
 
     public static Builder from(OpenPosition openPosition) {
       return new Builder()
-          .instrument(openPosition.getInstrument())
-          .type(openPosition.getType())
-          .size(openPosition.getSize())
-          .price(openPosition.getPrice())
-          .markPrice(openPosition.getMarkPrice())
-          .leverage(openPosition.getLeverage())
-          .marginRatio(openPosition.getMarginRatio())
-          .timestamp(openPosition.getTimestamp());
+              .instrument(openPosition.getInstrument())
+              .type(openPosition.getType())
+              .size(openPosition.getSize())
+              .price(openPosition.getPrice())
+              .markPrice(openPosition.getMarkPrice())
+              .liquidationPrice(openPosition.getLiquidationPrice())
+              .leverage(openPosition.getLeverage())
+              .marginRatio(openPosition.getMarginRatio())
+              .unrealizedProfit(openPosition.getUnrealizedProfit())
+              .timestamp(openPosition.getTimestamp());
     }
 
     public Builder instrument(final Instrument instrument) {
@@ -178,6 +194,11 @@ public class OpenPosition implements Serializable {
       return this;
     }
 
+    public Builder liquidationPrice(final BigDecimal liquidationPrice) {
+      this.liquidationPrice = liquidationPrice;
+      return this;
+    }
+
     public Builder leverage(final BigDecimal leverage) {
       this.leverage = leverage;
       return this;
@@ -188,13 +209,18 @@ public class OpenPosition implements Serializable {
       return this;
     }
 
+    public Builder unrealizedProfit(final BigDecimal unrealizedProfit) {
+      this.unrealizedProfit = unrealizedProfit;
+      return this;
+    }
+
     public Builder timestamp(final Date timestamp) {
       this.timestamp = timestamp;
       return this;
     }
 
     public OpenPosition build() {
-      return new OpenPosition(instrument, type, size, price, markPrice, leverage, marginRatio, timestamp);
+      return new OpenPosition(instrument, type, size, price, markPrice, liquidationPrice, leverage, marginRatio, unrealizedProfit, timestamp);
     }
   }
 }

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitAdapters.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitAdapters.java
@@ -25,6 +25,7 @@ import org.knowm.xchange.deribit.v2.dto.trade.OrderType;
 import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.derivative.OptionsContract;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.account.AccountMargin;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.Fee;
 import org.knowm.xchange.dto.account.OpenPosition;
@@ -42,7 +43,7 @@ import org.knowm.xchange.instrument.Instrument;
 
 public class DeribitAdapters {
   private static final String IMPLIED_COUNTER = "USD";
-  private static final String PERPETUAL = "perpetual";
+  private static final String PERPETUAL = "PERPETUAL";
   private static final int CURRENCY_SCALE = 8;
   private static final ThreadLocal<DateFormat> DATE_PARSER =
       ThreadLocal.withInitial(() -> new SimpleDateFormat("ddMMMyy"));
@@ -241,8 +242,10 @@ public class DeribitAdapters {
                 : p.getDirection() == Direction.sell ? OpenPosition.Type.SHORT : null)
         .price(p.getAveragePrice())
         .markPrice(p.getMarkPrice())
-        .leverage(p.getLeverage())   
-        .marginRatio(getMarginRatio(p))    
+        .liquidationPrice(p.getEstimatedLiquidationPrice())
+        .leverage(p.getLeverage())
+        .marginRatio(getMarginRatio(p))
+        .unrealizedProfit(p.getFloatingProfitLoss())
         .build();
   }
 
@@ -349,6 +352,10 @@ public class DeribitAdapters {
             .map(DeribitAdapters::adaptUserTrade)
             .collect(Collectors.toList()),
         Trades.TradeSortType.SortByTimestamp);
+  }
+
+  public static AccountMargin adapt(Currency c, AccountSummary accountSummary) {
+    return new AccountMargin(c, accountSummary.getMarginBalance(), accountSummary.getSessionUpl());
   }
 
   private static UserTrade adaptUserTrade(org.knowm.xchange.deribit.v2.dto.trade.Trade trade) {

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitExchange.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitExchange.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSharedParameters;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.deribit.v2.dto.Kind;
@@ -45,13 +46,15 @@ public class DeribitExchange extends BaseExchange implements Exchange {
     //    exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("Deribit");
     exchangeSpecification.setExchangeDescription("Deribit is a Bitcoin futures exchange");
+    exchangeSpecification.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_USE_SANDBOX, false);
+    exchangeSpecification.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_SANDBOX_SSL_URI, "https://test.deribit.com");
     return exchangeSpecification;
   }
 
   public ExchangeSpecification getSandboxExchangeSpecification() {
 
-    ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass());
-    exchangeSpecification.setSslUri("https://test.deribit.com/");
+    ExchangeSpecification exchangeSpecification = getDefaultExchangeSpecification();
+    exchangeSpecification.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_USE_SANDBOX, true);
     exchangeSpecification.setHost("test.deribit.com");
     //    exchangeSpecification.setPort(80);
     return exchangeSpecification;

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/DeribitAdaptersTest.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/DeribitAdaptersTest.java
@@ -52,6 +52,12 @@ public class DeribitAdaptersTest {
   }
 
   @Test
+  public void adaptInstrumentName() {
+    assertThat(DeribitAdapters.adaptInstrumentName(new FuturesContract("BTC/USD/perpetual"))).isEqualTo("BTC-PERPETUAL");
+    assertThat(DeribitAdapters.adaptInstrumentName(new OptionsContract("BTC/USD/210924/7000/P"))).isEqualTo("BTC-24SEP21-7000-P");
+  }
+
+  @Test
   public void adaptTicker() throws IOException {
     // given
     InputStream is =

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/DeribitExceptionIntegration.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/DeribitExceptionIntegration.java
@@ -7,6 +7,8 @@ import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.deribit.v2.dto.DeribitException;
 import org.knowm.xchange.deribit.v2.service.DeribitMarketDataService;
+import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.derivative.OptionsContract;
 import org.knowm.xchange.exceptions.CurrencyPairNotValidException;
 
 public class DeribitExceptionIntegration {
@@ -22,8 +24,7 @@ public class DeribitExceptionIntegration {
 
   @Test(expected = CurrencyPairNotValidException.class)
   public void getTickerThrowsExceptionTest() throws Exception {
-    CurrencyPair pair = new CurrencyPair("?", "?");
-    deribitMarketDataService.getTicker(pair);
+    deribitMarketDataService.getTicker(new FuturesContract("?/?/PERPETUAL"));
   }
 
   @Test(expected = DeribitException.class)

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/account/DeribitAccountServiceSample.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/account/DeribitAccountServiceSample.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.deribit.v2.service.account;
+
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.deribit.v2.DeribitExchange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class DeribitAccountServiceSample {
+    private static final Logger LOG = LoggerFactory.getLogger(DeribitAccountServiceSample.class);
+
+    private static final String apiKey = "api-key";
+    private static final String apiSecret = "api-secret";
+    private static final String user = "001";
+
+    public static void main(String[] args) throws InterruptedException {
+        DeribitExchange exchange = ExchangeFactory.INSTANCE.createExchange(DeribitExchange.class);
+
+        ExchangeSpecification specification = exchange.getSandboxExchangeSpecification();
+        specification.setApiKey(apiKey);
+        specification.setSecretKey(apiSecret);
+        exchange.applySpecification(specification);
+
+        ScheduledExecutorService openPositionsExecutor = Executors.newScheduledThreadPool(1);
+        openPositionsExecutor.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    LOG.info("account wallet: " + exchange.getAccountService().getAccountInfo().getWallet());
+                    LOG.info("account positions: " + exchange.getAccountService().getAccountInfo().getOpenPositions());
+                    LOG.info("account margin info: " + exchange.getAccountService().getAccountInfo().getAccountMargin());
+                } catch (Exception e) {
+                    LOG.error("error getting positions: " + e);
+                    e.printStackTrace();
+                }
+            }
+        }, 0, 15, TimeUnit.SECONDS); // every 15 seconds
+
+        Runtime.getRuntime().addShutdownHook(new Thread()
+        {
+            @Override
+            public void run()
+            {
+                LOG.info(exchange + " disconnected.\n");
+            }
+        });
+
+        TimeUnit.HOURS.sleep(1);
+    }
+}

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitOrderBookFetchIntegration.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitOrderBookFetchIntegration.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitOrderBook;
 import org.knowm.xchange.deribit.v2.service.DeribitMarketDataService;
+import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 
 public class DeribitOrderBookFetchIntegration {
@@ -34,8 +35,8 @@ public class DeribitOrderBookFetchIntegration {
 
   @Test
   public void getOrderBookTest() throws Exception {
-    CurrencyPair pair = new CurrencyPair("BTC", "PERPETUAL");
-    OrderBook orderBook = deribitMarketDataService.getOrderBook(pair, null);
+    FuturesContract instrument = new FuturesContract("BTC/USD/PERPETUAL");
+    OrderBook orderBook = deribitMarketDataService.getOrderBook(instrument, null);
 
     assertThat(orderBook).isNotNull();
     assertThat(orderBook.getBids()).isNotEmpty();

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitTickerFetchIntegration.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitTickerFetchIntegration.java
@@ -11,6 +11,8 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitTicker;
 import org.knowm.xchange.deribit.v2.service.DeribitMarketDataService;
+import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.derivative.OptionsContract;
 import org.knowm.xchange.dto.marketdata.Ticker;
 
 public class DeribitTickerFetchIntegration {
@@ -36,10 +38,10 @@ public class DeribitTickerFetchIntegration {
 
   @Test
   public void getTickerTest() throws Exception {
-    CurrencyPair pair = new CurrencyPair("BTC", "PERPETUAL");
-    Ticker ticker = deribitMarketDataService.getTicker(pair);
+    FuturesContract instrument = new FuturesContract("BTC/USD/PERPETUAL");
+    Ticker ticker = deribitMarketDataService.getTicker(instrument);
 
     assertThat(ticker).isNotNull();
-    assertThat(ticker.getCurrencyPair()).isEqualTo(pair);
+    assertThat(ticker.getInstrument()).isEqualTo(instrument);
   }
 }

--- a/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitTradesFetchIntegration.java
+++ b/xchange-deribit/src/test/java/org/knowm/xchange/deribit/v2/service/marketdata/DeribitTradesFetchIntegration.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitTrades;
 import org.knowm.xchange.deribit.v2.service.DeribitMarketDataService;
+import org.knowm.xchange.derivative.FuturesContract;
 import org.knowm.xchange.dto.marketdata.Trades;
 
 public class DeribitTradesFetchIntegration {
@@ -35,8 +36,8 @@ public class DeribitTradesFetchIntegration {
 
   @Test
   public void getTradesTest() throws Exception {
-    CurrencyPair pair = new CurrencyPair("BTC", "PERPETUAL");
-    Trades trades = deribitMarketDataService.getTrades(pair);
+    FuturesContract instrument = new FuturesContract("BTC/USD/PERPETUAL");
+    Trades trades = deribitMarketDataService.getTrades(instrument);
 
     assertThat(trades).isNotNull();
     assertThat(trades.getTrades()).isNotEmpty();

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAuthenticated.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/FtxAuthenticated.java
@@ -38,7 +38,8 @@ public interface FtxAuthenticated extends Ftx {
       @HeaderParam("FTX-KEY") String apiKey,
       @HeaderParam("FTX-TS") Long nonce,
       @HeaderParam("FTX-SIGN") ParamsDigest signature,
-      @HeaderParam("FTX-SUBACCOUNT") String subaccount)
+      @HeaderParam("FTX-SUBACCOUNT") String subaccount,
+      @QueryParam("showAvgPrice") boolean showAvgPrice)
       throws IOException, FtxException;
 
   @DELETE

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/account/FtxPositionDto.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/account/FtxPositionDto.java
@@ -52,22 +52,30 @@ public class FtxPositionDto {
   @JsonProperty("collateralUsed")
   private final BigDecimal collateralUsed;
 
+  @JsonProperty("recentPnl")
+  private final BigDecimal recentPnl;
+
+  @JsonProperty("recentAverageOpenPrice")
+  private final BigDecimal recentAverageOpenPrice;
+
   public FtxPositionDto(
-      @JsonProperty("cost") BigDecimal cost,
-      @JsonProperty("entryPrice") BigDecimal entryPrice,
-      @JsonProperty("estimatedLiquidationPrice") BigDecimal estimatedLiquidationPrice,
-      @JsonProperty("future") String future,
-      @JsonProperty("initialMarginRequirement") BigDecimal initialMarginRequirement,
-      @JsonProperty("longOrderSize") BigDecimal longOrderSize,
-      @JsonProperty("maintenanceMarginRequirement") BigDecimal maintenanceMarginRequirement,
-      @JsonProperty("netSize") BigDecimal netSize,
-      @JsonProperty("openSize") BigDecimal openSize,
-      @JsonProperty("realizedPnl") BigDecimal realizedPnl,
-      @JsonProperty("shortOrderSize") BigDecimal shortOrderSize,
-      @JsonProperty("side") FtxOrderSide side,
-      @JsonProperty("size") BigDecimal size,
-      @JsonProperty("unrealizedPnl") BigDecimal unrealizedPnl,
-      @JsonProperty("collateralUsed") BigDecimal collateralUsed) {
+          @JsonProperty("cost") BigDecimal cost,
+          @JsonProperty("entryPrice") BigDecimal entryPrice,
+          @JsonProperty("estimatedLiquidationPrice") BigDecimal estimatedLiquidationPrice,
+          @JsonProperty("future") String future,
+          @JsonProperty("initialMarginRequirement") BigDecimal initialMarginRequirement,
+          @JsonProperty("longOrderSize") BigDecimal longOrderSize,
+          @JsonProperty("maintenanceMarginRequirement") BigDecimal maintenanceMarginRequirement,
+          @JsonProperty("netSize") BigDecimal netSize,
+          @JsonProperty("openSize") BigDecimal openSize,
+          @JsonProperty("realizedPnl") BigDecimal realizedPnl,
+          @JsonProperty("shortOrderSize") BigDecimal shortOrderSize,
+          @JsonProperty("side") FtxOrderSide side,
+          @JsonProperty("size") BigDecimal size,
+          @JsonProperty("unrealizedPnl") BigDecimal unrealizedPnl,
+          @JsonProperty("collateralUsed") BigDecimal collateralUsed,
+          @JsonProperty("recentPnl") BigDecimal recentPnl,
+          @JsonProperty("recentAverageOpenPrice") BigDecimal recentAverageOpenPrice) {
     this.cost = cost;
     this.entryPrice = entryPrice;
     this.estimatedLiquidationPrice = estimatedLiquidationPrice;
@@ -83,6 +91,8 @@ public class FtxPositionDto {
     this.size = size;
     this.unrealizedPnl = unrealizedPnl;
     this.collateralUsed = collateralUsed;
+    this.recentPnl = recentPnl;
+    this.recentAverageOpenPrice = recentAverageOpenPrice;
   }
 
   public BigDecimal getCost() {
@@ -145,39 +155,30 @@ public class FtxPositionDto {
     return collateralUsed;
   }
 
+  public BigDecimal getRecentPnl() {
+    return recentPnl;
+  }
+
   @Override
   public String toString() {
-    return "FtxPositionDto{"
-        + "cost="
-        + cost
-        + ", entryPrice="
-        + entryPrice
-        + ", estimatedLiquidationPrice="
-        + estimatedLiquidationPrice
-        + ", future="
-        + future
-        + ", initialMarginRequirement="
-        + initialMarginRequirement
-        + ", longOrderSize="
-        + longOrderSize
-        + ", maintenanceMarginRequirement="
-        + maintenanceMarginRequirement
-        + ", netSize="
-        + netSize
-        + ", openSize="
-        + openSize
-        + ", realizedPnl="
-        + realizedPnl
-        + ", shortOrderSize="
-        + shortOrderSize
-        + ", side="
-        + side
-        + ", size="
-        + size
-        + ", unrealizedPnl="
-        + unrealizedPnl
-        + ", collateralUsed="
-        + collateralUsed
-        + '}';
+    return "FtxPositionDto{" +
+            "cost=" + cost +
+            ", entryPrice=" + entryPrice +
+            ", estimatedLiquidationPrice=" + estimatedLiquidationPrice +
+            ", future='" + future + '\'' +
+            ", initialMarginRequirement=" + initialMarginRequirement +
+            ", longOrderSize=" + longOrderSize +
+            ", maintenanceMarginRequirement=" + maintenanceMarginRequirement +
+            ", netSize=" + netSize +
+            ", openSize=" + openSize +
+            ", realizedPnl=" + realizedPnl +
+            ", shortOrderSize=" + shortOrderSize +
+            ", side=" + side +
+            ", size=" + size +
+            ", unrealizedPnl=" + unrealizedPnl +
+            ", collateralUsed=" + collateralUsed +
+            ", recentPnl=" + recentPnl +
+            ", recentAverageOpenPrice=" + recentAverageOpenPrice +
+            '}';
   }
 }

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/account/FtxPositionDto.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/dto/account/FtxPositionDto.java
@@ -159,6 +159,10 @@ public class FtxPositionDto {
     return recentPnl;
   }
 
+  public BigDecimal getRecentAverageOpenPrice() {
+    return recentAverageOpenPrice;
+  }
+
   @Override
   public String toString() {
     return "FtxPositionDto{" +

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.ftx.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.OpenPosition;
 import org.knowm.xchange.ftx.FtxAdapters;
 import org.knowm.xchange.ftx.dto.FtxResponse;
 import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
@@ -10,6 +11,7 @@ import org.knowm.xchange.service.account.params.AccountLeverageParams;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.List;
 
 public class FtxAccountService extends FtxAccountServiceRaw implements AccountService {
 
@@ -29,7 +31,7 @@ public class FtxAccountService extends FtxAccountServiceRaw implements AccountSe
         ftxAccountInformation,
         getFtxWalletBalances(subaccount),
         ((FtxTradeService) exchange.getTradeService())
-            .getOpenPositionsForSubaccount(subaccount, leverage)
+            .getOpenPositionsForSubaccount(subaccount, leverage, true)
             .getOpenPositions());
   }
 

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
@@ -24,12 +24,12 @@ public class FtxAccountService extends FtxAccountServiceRaw implements AccountSe
 
   public AccountInfo getSubaccountInfo(String subaccount) throws IOException {
     FtxResponse<FtxAccountDto> ftxAccountInformation = getFtxAccountInformation(subaccount);
-    BigDecimal leverage = ftxAccountInformation.getResult().getLeverage();
+    FtxAccountDto accountDto = ftxAccountInformation.getResult();
     return FtxAdapters.adaptAccountInfo(
         ftxAccountInformation,
         getFtxWalletBalances(subaccount),
         ((FtxTradeService) exchange.getTradeService())
-            .getOpenPositionsForSubaccount(subaccount, leverage, true)
+            .getOpenPositionsForSubaccount(subaccount, accountDto, true)
             .getOpenPositions());
   }
 

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxAccountService.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.ftx.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.dto.account.AccountInfo;
-import org.knowm.xchange.dto.account.OpenPosition;
 import org.knowm.xchange.ftx.FtxAdapters;
 import org.knowm.xchange.ftx.dto.FtxResponse;
 import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
@@ -11,7 +10,6 @@ import org.knowm.xchange.service.account.params.AccountLeverageParams;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.List;
 
 public class FtxAccountService extends FtxAccountServiceRaw implements AccountService {
 

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
@@ -91,7 +91,7 @@ public class FtxTradeService extends FtxTradeServiceRaw implements TradeService 
             .getFtxAccountInformation(subaccount)
             .getResult()
             .getLeverage();
-    return getOpenPositionsForSubaccount(subaccount, leverage);
+    return getOpenPositionsForSubaccount(subaccount, leverage, false);
   }
 
   @Override

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeService.java
@@ -8,6 +8,7 @@ import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.ftx.FtxAdapters;
+import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamInstrument;
@@ -86,12 +87,10 @@ public class FtxTradeService extends FtxTradeServiceRaw implements TradeService 
   @Override
   public OpenPositions getOpenPositions() throws IOException {
     String subaccount = exchange.getExchangeSpecification().getUserName();
-    BigDecimal leverage =
-        ((FtxAccountService) exchange.getAccountService())
+    FtxAccountDto accountDto = ((FtxAccountService) exchange.getAccountService())
             .getFtxAccountInformation(subaccount)
-            .getResult()
-            .getLeverage();
-    return getOpenPositionsForSubaccount(subaccount, leverage, false);
+            .getResult();
+    return getOpenPositionsForSubaccount(subaccount, accountDto, false);
   }
 
   @Override

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.ftx.FtxAdapters;
 import org.knowm.xchange.ftx.FtxException;
 import org.knowm.xchange.ftx.dto.FtxResponse;
+import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
 import org.knowm.xchange.ftx.dto.account.FtxPositionDto;
 import org.knowm.xchange.ftx.dto.trade.*;
 import org.knowm.xchange.instrument.Instrument;
@@ -273,8 +274,9 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     }
   }
 
-  public OpenPositions getOpenPositionsForSubaccount(String subaccount, BigDecimal leverage, boolean showAvgPrice) throws IOException {
-    return FtxAdapters.adaptOpenPositions(getFtxPositions(subaccount, showAvgPrice).getResult(), leverage);
+  public OpenPositions getOpenPositionsForSubaccount(String subaccount, FtxAccountDto accountDto, boolean showAvgPrice) throws IOException {
+    List<FtxPositionDto> positionDtos = getFtxPositions(subaccount, showAvgPrice).getResult();
+    return FtxAdapters.adaptOpenPositions(positionDtos, accountDto.getLeverage(), accountDto.getTotalAccountValue());
   }
 
   public FtxResponse<List<FtxPositionDto>> getFtxPositions(String subaccount, boolean showAvgPrice)

--- a/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
+++ b/xchange-ftx/src/main/java/org/knowm/xchange/ftx/service/FtxTradeServiceRaw.java
@@ -273,18 +273,19 @@ public class FtxTradeServiceRaw extends FtxBaseService {
     }
   }
 
-  public OpenPositions getOpenPositionsForSubaccount(String subaccount, BigDecimal leverage) throws IOException {
-    return FtxAdapters.adaptOpenPositions(getFtxPositions(subaccount).getResult(), leverage);
+  public OpenPositions getOpenPositionsForSubaccount(String subaccount, BigDecimal leverage, boolean showAvgPrice) throws IOException {
+    return FtxAdapters.adaptOpenPositions(getFtxPositions(subaccount, showAvgPrice).getResult(), leverage);
   }
 
-  public FtxResponse<List<FtxPositionDto>> getFtxPositions(String subaccount)
+  public FtxResponse<List<FtxPositionDto>> getFtxPositions(String subaccount, boolean showAvgPrice)
       throws FtxException, IOException {
     try {
       return ftx.getFtxPositions(
           exchange.getExchangeSpecification().getApiKey(),
           exchange.getNonceFactory().createValue(),
           signatureCreator,
-          subaccount);
+          subaccount,
+          showAvgPrice);
     } catch (FtxException e) {
       throw new FtxException(e.getMessage());
     }

--- a/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FTXExchangeExample.java
+++ b/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FTXExchangeExample.java
@@ -1,0 +1,50 @@
+package org.knowm.xchange.ftx;
+
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.ExchangeSharedParameters;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class FTXExchangeExample {
+
+	public static final boolean SANDBOX = false;
+	public static final String API_KEY = "key";
+	public static final String API_SECRET = "secret";
+	public static final String USER_NAME = "name";
+
+	public static void main(String[] args) throws InterruptedException {
+		// Far safer than temporarily adding these to code that might get committed to VCS
+
+		ExchangeSpecification spec =
+				ExchangeFactory.INSTANCE
+						.createExchange(FtxExchange.class)
+						.getDefaultExchangeSpecification();
+
+		spec.setApiKey(API_KEY);
+		spec.setSecretKey(API_SECRET);
+		spec.setUserName(USER_NAME);
+		spec.setShouldLoadRemoteMetaData(!SANDBOX);
+		spec.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_USE_SANDBOX, SANDBOX);
+		FtxExchange exchange =
+				(FtxExchange) ExchangeFactory.INSTANCE.createExchange(spec);
+
+		System.out.println("exchange spec: " + exchange.getExchangeSpecification());
+
+		try {
+			AccountInfo accountInfo = exchange.getAccountService().getAccountInfo();
+			System.out.println("account info: {}" + accountInfo);
+			System.out.println("open positions: {}" + accountInfo.getOpenPositions());
+			System.out.println("account margin: {}" + accountInfo.getAccountMargin());
+			System.out.println("account balances: {}" + accountInfo.getWallet("margin").getBalance(Currency.USDT));
+			System.out.println("account balances: {}" + accountInfo.getWallet("spot").getBalance(Currency.USDT));
+		} catch (IOException e) {
+			System.out.println("error getting account" + e);
+		}
+	}
+}

--- a/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
+++ b/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
@@ -1,0 +1,38 @@
+package org.knowm.xchange.ftx;
+
+import org.junit.Test;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountMargin;
+import org.knowm.xchange.dto.account.OpenPositions;
+import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
+import org.knowm.xchange.ftx.dto.account.FtxPositionDto;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FtxAdaptersTest {
+
+    @Test
+    public void testAccountInfo_wallet() {
+		BigDecimal leverage = BigDecimal.ONE;
+		List<FtxPositionDto> positions = Arrays.asList(
+                new FtxPositionDto(null, null, null, "BTC-PERP", null, null, null, null, null, null, null, null, BigDecimal.ZERO, null, null, BigDecimal.TEN, null),
+                new FtxPositionDto(null, null, null, "ETH-PERP", null, null, null, null, null, null, null, null, BigDecimal.TEN, null, null, BigDecimal.ONE, null),
+                new FtxPositionDto(null, null, null, "XRP-PERP", null, null, null, null, null, null, null, null, BigDecimal.TEN, null, null, BigDecimal.TEN.negate(), null)
+        );
+		BigDecimal totalAccountValue = new BigDecimal("1000");
+		BigDecimal unrealizedProfit = new BigDecimal("9").negate();
+		BigDecimal marginBalance = totalAccountValue.add(unrealizedProfit);
+
+		FtxAccountDto ftxAccountDto = new FtxAccountDto(false, null, null, null, null, false, null, null, null, null, null, totalAccountValue, BigDecimal.ONE, null, positions);
+        OpenPositions openPositions = FtxAdapters.adaptOpenPositions(positions, leverage);
+
+        AccountMargin margin = FtxAdapters.getAccountMargin(ftxAccountDto, openPositions.getOpenPositions());
+        assertThat(margin.getCurrency()).isEqualTo(Currency.USD);
+		assertThat(margin.getUnrealizedProfit()).isEqualByComparingTo(unrealizedProfit);
+        assertThat(margin.getMarginBalance()).isEqualByComparingTo(marginBalance);
+    }
+}

--- a/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
+++ b/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
@@ -2,13 +2,18 @@ package org.knowm.xchange.ftx;
 
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.AccountMargin;
+import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.OpenPositions;
+import org.knowm.xchange.ftx.dto.FtxResponse;
 import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
 import org.knowm.xchange.ftx.dto.account.FtxPositionDto;
+import org.knowm.xchange.ftx.dto.account.FtxWalletBalanceDto;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -16,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FtxAdaptersTest {
 
     @Test
-    public void testAccountInfo_wallet() {
+    public void testGetAccountMargin() {
 		BigDecimal leverage = BigDecimal.ONE;
 		List<FtxPositionDto> positions = Arrays.asList(
                 new FtxPositionDto(null, null, null, "BTC-PERP", null, null, null, null, null, null, null, null, BigDecimal.ZERO, null, null, BigDecimal.TEN, null),
@@ -35,4 +40,35 @@ public class FtxAdaptersTest {
 		assertThat(margin.getUnrealizedProfit()).isEqualByComparingTo(unrealizedProfit);
         assertThat(margin.getMarginBalance()).isEqualByComparingTo(marginBalance);
     }
+
+	@Test
+	public void testGetAccountInfo_wallet() {
+		FtxAccountDto account = new FtxAccountDto(false, null, null, null, null, false, null, null, null, null, null, null, null, null, Collections.emptyList());
+		List<FtxWalletBalanceDto> balances = Arrays.asList(
+			new FtxWalletBalanceDto(Currency.USD, BigDecimal.ONE, BigDecimal.TEN),
+			new FtxWalletBalanceDto(Currency.BTC, BigDecimal.ZERO, BigDecimal.ONE)
+		);
+		FtxResponse<FtxAccountDto> accountResponse = new FtxResponse<>(true, account, false);
+		FtxResponse<List<FtxWalletBalanceDto>> balancesResponse = new FtxResponse<>(true, balances, false);
+
+		AccountInfo accountInfo = FtxAdapters.adaptAccountInfo(accountResponse, balancesResponse, Collections.emptyList());
+
+		assertThat(accountInfo).isNotNull();
+		assertThat(accountInfo.getWallets().size()).isEqualTo(1);
+		assertThat(accountInfo.getWallet().getBalances().size()).isEqualTo(2);
+		assertThat(accountInfo.getWallet().getBalance(Currency.USD)).isNotNull();
+		assertThat(accountInfo.getWallet().getBalance(Currency.BTC)).isNotNull();
+		assertThat(accountInfo.getWallet().getBalance(Currency.EUR)).isEqualTo(Balance.zero(Currency.EUR));
+	}
+
+	@Test
+	public void testAdaptBalance() {
+		Currency currency = Currency.USD;
+		BigDecimal free = new BigDecimal("1992.58580007");
+		BigDecimal total = new BigDecimal("1995.35220007");
+		Balance balance = FtxAdapters.adaptBalance(new FtxWalletBalanceDto(currency, free, total));
+		assertThat(balance.getAvailable()).isEqualByComparingTo(new BigDecimal("1992.58580007"));
+		assertThat(balance.getTotal()).isEqualByComparingTo(new BigDecimal("1995.35220007"));
+		assertThat(balance.getFrozen()).isEqualByComparingTo(new BigDecimal("2.76640000"));
+	}
 }

--- a/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
+++ b/xchange-ftx/src/test/java/org/knowm/xchange/ftx/FtxAdaptersTest.java
@@ -2,14 +2,14 @@ package org.knowm.xchange.ftx;
 
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
-import org.knowm.xchange.dto.account.AccountInfo;
-import org.knowm.xchange.dto.account.AccountMargin;
-import org.knowm.xchange.dto.account.Balance;
-import org.knowm.xchange.dto.account.OpenPositions;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.derivative.FuturesContract;
+import org.knowm.xchange.dto.account.*;
 import org.knowm.xchange.ftx.dto.FtxResponse;
 import org.knowm.xchange.ftx.dto.account.FtxAccountDto;
 import org.knowm.xchange.ftx.dto.account.FtxPositionDto;
 import org.knowm.xchange.ftx.dto.account.FtxWalletBalanceDto;
+import org.knowm.xchange.ftx.dto.trade.FtxOrderSide;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FtxAdaptersTest {
 
-    @Test
+	@Test
     public void testGetAccountMargin() {
 		BigDecimal leverage = BigDecimal.ONE;
 		List<FtxPositionDto> positions = Arrays.asList(
@@ -33,7 +33,7 @@ public class FtxAdaptersTest {
 		BigDecimal marginBalance = totalAccountValue.add(unrealizedProfit);
 
 		FtxAccountDto ftxAccountDto = new FtxAccountDto(false, null, null, null, null, false, null, null, null, null, null, totalAccountValue, BigDecimal.ONE, null, positions);
-        OpenPositions openPositions = FtxAdapters.adaptOpenPositions(positions, leverage);
+        OpenPositions openPositions = FtxAdapters.adaptOpenPositions(positions, leverage, BigDecimal.ZERO);
 
         AccountMargin margin = FtxAdapters.getAccountMargin(ftxAccountDto, openPositions.getOpenPositions());
         assertThat(margin.getCurrency()).isEqualTo(Currency.USD);
@@ -71,4 +71,190 @@ public class FtxAdaptersTest {
 		assertThat(balance.getTotal()).isEqualByComparingTo(new BigDecimal("1995.35220007"));
 		assertThat(balance.getFrozen()).isEqualByComparingTo(new BigDecimal("2.76640000"));
 	}
+
+	@Test
+	public void testGetPositionSize_buy() {
+		BigDecimal size = BigDecimal.ONE;
+		FtxOrderSide side = FtxOrderSide.buy;
+		FtxPositionDto dto = new FtxPositionDto(null, null, null, null, null, null, null, null, null, null, null, side, size, null, null, null, null);
+		assertThat(FtxAdapters.getPositionSize(dto)).isEqualByComparingTo(size);
+	}
+
+	@Test
+	public void testGetPositionSize_sell() {
+		BigDecimal size = BigDecimal.ONE;
+		FtxOrderSide side = FtxOrderSide.sell;
+		FtxPositionDto dto = new FtxPositionDto(null, null, null, null, null, null, null, null, null, null, null, side, size, null, null, null, null);
+		assertThat(FtxAdapters.getPositionSize(dto)).isEqualByComparingTo(size.negate());
+	}
+
+
+	@Test
+	public void testGetPositionType_long() {
+		FtxOrderSide side = FtxOrderSide.buy;
+		FtxPositionDto dto = new FtxPositionDto(null, null, null, null, null, null, null, null, null, null, null, side, BigDecimal.ONE, null, null, null, null);
+		assertThat(FtxAdapters.getPositionType(dto)).isEqualByComparingTo(OpenPosition.Type.LONG);
+	}
+
+	@Test
+	public void testGetPositionType_short() {
+		FtxOrderSide side = FtxOrderSide.sell;
+		FtxPositionDto dto = new FtxPositionDto(null, null, null, null, null, null, null, null, null, null, null, side, BigDecimal.ONE, null, null, null, null);
+		assertThat(FtxAdapters.getPositionType(dto)).isEqualByComparingTo(OpenPosition.Type.SHORT);
+	}
+
+	@Test
+	public void testAdaptOpenPosition_instrument() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getInstrument()).isEqualTo(new FuturesContract(CurrencyPair.ETH_USD, null));
+	}
+
+	@Test
+	public void testGetLiquidationPrice_zero() {
+		BigDecimal price = BigDecimal.ZERO;
+		FtxPositionDto dto = new FtxPositionDto(null, null, price, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(FtxAdapters.getPositionEstimatedLiquidationPrice(dto)).isNull();
+	}
+
+	@Test
+	public void testGetLiquidationPrice_null() {
+		BigDecimal price = null;
+		FtxPositionDto dto = new FtxPositionDto(null, null, price, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(FtxAdapters.getPositionEstimatedLiquidationPrice(dto)).isNull();
+	}
+
+	@Test
+	public void testGetLiquidationPrice_value() {
+		BigDecimal price = BigDecimal.ONE;
+		FtxPositionDto dto = new FtxPositionDto(null, null, price, null, null, null, null, null, null, null, null, null, null, null, null, null, null);
+		assertThat(FtxAdapters.getPositionEstimatedLiquidationPrice(dto)).isEqualByComparingTo(price);
+	}
+
+	@Test
+	public void testAdaptOpenPosition_size() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getSize()).isEqualByComparingTo(new BigDecimal("0.001"));
+	}
+
+	@Test
+	public void testAdaptOpenPosition_type() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getType()).isEqualTo(OpenPosition.Type.LONG);
+	}
+
+	@Test
+	public void testAdaptOpenPosition_leverage() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getLeverage()).isEqualByComparingTo(FTX_POSITION_LEVERAGE);
+	}
+
+	@Test
+	public void testAdaptOpenPosition_price() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getPrice()).isEqualByComparingTo(new BigDecimal("2750.3"));
+	}
+
+	@Test
+	public void testAdaptOpenPosition_markPrice() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getMarkPrice()).isNull();
+	}
+
+	@Test
+	public void testAdaptOpenPosition_liquidationPrice() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getLiquidationPrice()).isNull();
+	}
+
+	@Test
+	public void testAdaptOpenPosition_mr() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getMarginRatio()).isEqualByComparingTo(BigDecimal.ZERO);
+	}
+
+	@Test
+	public void testAdaptOpenPosition_pnl() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getUnrealizedProfit()).isEqualByComparingTo(new BigDecimal("0.0371"));
+	}
+
+	@Test
+	public void testAdaptOpenPosition_time() {
+		OpenPosition position = FtxAdapters.adaptOpenPosition(FTX_POSITION_DTO, FTX_POSITION_LEVERAGE, FTX_TOTAL_ACCOUNT_VALUE);
+		assertThat(position.getTimestamp()).isNull();
+	}
+
+	@Test
+	public void testGetMarginFraction_position_smaller_then_total() {
+		BigDecimal totalValue = new BigDecimal("2000.0");
+		BigDecimal positionValue = new BigDecimal("150.0");
+		assertThat(FtxAdapters.getMarginFraction(totalValue, positionValue)).isEqualByComparingTo(new BigDecimal("13.3"));
+	}
+
+	@Test
+	public void testGetMarginFraction_position_greater_then_total() {
+		BigDecimal totalValue = new BigDecimal("2000.0");
+		BigDecimal positionValue = new BigDecimal("10000.0");
+		assertThat(FtxAdapters.getMarginFraction(totalValue, positionValue)).isEqualByComparingTo(new BigDecimal("0.2"));
+	}
+
+	@Test
+	public void testGetMarginRatio_position_greater_then_total() {
+		BigDecimal marginMaintenance = new BigDecimal("0.03"); // 3%
+		BigDecimal marginFraction = new BigDecimal("0.2"); // 20%, leverage 5x; total 100$; position 500$
+		assertThat(FtxAdapters.getMarginRatio(marginMaintenance, marginFraction)).isEqualByComparingTo(new BigDecimal("0.15"));
+	}
+
+	@Test
+	public void testGetMarginRatio_position_smaller_then_total() {
+		BigDecimal marginMaintenance = new BigDecimal("0.03"); // 3%
+		BigDecimal marginFraction = new BigDecimal("13.33"); // 1333%
+		assertThat(FtxAdapters.getMarginRatio(marginMaintenance, marginFraction)).isEqualByComparingTo(new BigDecimal("0.0023"));
+	}
+
+	private static final BigDecimal FTX_TOTAL_ACCOUNT_VALUE = new BigDecimal("1995.37");
+	private static final BigDecimal FTX_POSITION_LEVERAGE = new BigDecimal("1");
+	private static final FtxPositionDto FTX_POSITION_DTO = new FtxPositionDto(new BigDecimal("2.7874"),
+			new BigDecimal("2787.4"),
+			new BigDecimal("0.0"),
+			"ETH-PERP",
+			new BigDecimal("1.0"),
+			new BigDecimal("0.0"),
+			new BigDecimal("0.03"),
+			new BigDecimal("0.001"),
+			new BigDecimal("0.001"),
+			new BigDecimal("3.52180901"),
+			new BigDecimal("0.0"),
+			FtxOrderSide.buy,
+			new BigDecimal("0.001"),
+			new BigDecimal("0.0"),
+			new BigDecimal("2.7874"),
+			new BigDecimal("0.0371"),
+			new BigDecimal("2750.3"));
+
+/*
+	{
+		"future": "ETH-PERP",
+		"size": 0.001,
+		"side": "buy",
+		"netSize": 0.001,
+		"longOrderSize": 0.0,
+		"shortOrderSize": 0.0,
+		"cost": 2.7874,
+		"entryPrice": 2787.4,
+		"unrealizedPnl": 0.0,
+		"realizedPnl": 3.52180901,
+		"initialMarginRequirement": 1.0,
+		"maintenanceMarginRequirement": 0.03,
+		"openSize": 0.001,
+		"collateralUsed": 2.7874,
+		"estimatedLiquidationPrice": 0.0,
+		"recentAverageOpenPrice": 2750.3,
+		"recentPnl": 0.0371,
+		"recentBreakEvenPrice": 2750.3,
+		"cumulativeBuySize": 0.001,
+		"cumulativeSellSize": 0.0
+	}
+ */
+
 }

--- a/xchange-ftx/src/test/resources/logback-test.xml
+++ b/xchange-ftx/src/test/resources/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+
+    <!-- Standard console appender for checking activity (short on detail) -->
+    <appender name="CONSOLE_APPENDER" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- Simplified standard logging encoder -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%contextName] [%thread] %-5level %logger{36} - %msg %xEx%n</pattern>
+        </encoder>
+    </appender>
+
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE_APPENDER"/>
+    </root>
+
+
+    <!-- Define logging for organization applications only -->
+    <logger name="org.knowm.xchange.ftx" level="DEBUG"/>
+    <!--<logger name="si.mazi.rescu" level="DEBUG"/>-->
+
+</configuration>

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceFuturesStreamingExchange.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceFuturesStreamingExchange.java
@@ -10,6 +10,8 @@ import info.bitrich.xchangestream.service.netty.ConnectionStateModel;
 import info.bitrich.xchangestream.util.Events;
 import io.reactivex.rxjava3.core.Completable;
 import io.reactivex.rxjava3.core.Flowable;
+import org.knowm.xchange.ExchangeSharedParameters;
+import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.binance.BinanceAuthenticated;
 import org.knowm.xchange.binance.futures.BinanceFuturesAuthenticated;
 import org.knowm.xchange.binance.BinanceFuturesExchange;
@@ -26,8 +28,6 @@ import java.util.stream.Stream;
 
 public class BinanceFuturesStreamingExchange extends BinanceFuturesExchange implements StreamingExchange {
     private static final Logger LOG = LoggerFactory.getLogger(BinanceFuturesStreamingExchange.class);
-    private static final String API_BASE_URI = "wss://fstream.binance.com";
-    private static final String SANDBOX_API_BASE_URI = "wss://stream.binancefuture.com";
     protected static final String USE_HIGHER_UPDATE_FREQUENCY =
             "Binance_Orderbook_Use_Higher_Frequency";
 
@@ -58,6 +58,14 @@ public class BinanceFuturesStreamingExchange extends BinanceFuturesExchange impl
         }
     }
 
+    @Override
+    public ExchangeSpecification getDefaultExchangeSpecification() {
+        ExchangeSpecification exchangeSpecification = super.getDefaultExchangeSpecification();
+        exchangeSpecification.setStreamingUri("wss://fstream.binance.com");
+        exchangeSpecification.setExchangeSpecificParametersItem(ExchangeSharedParameters.PARAM_SANDBOX_STREAMING_URI, "wss://stream.binancefuture.com");
+        return exchangeSpecification;
+    }
+
     /**
      * Binance streaming API expects connections to multiple channels to be defined at connection
      * time. To define the channels for this connection pass a `ProductSubscription` in at connection
@@ -77,9 +85,7 @@ public class BinanceFuturesStreamingExchange extends BinanceFuturesExchange impl
                     "Exchange only handles a single connection - disconnect the current connection.");
         }
 
-        final boolean useSandbox =
-                Boolean.TRUE.equals(exchangeSpecification.getExchangeSpecificParametersItem(Parameters.PARAM_USE_SANDBOX));
-        final String apiUri = useSandbox ? SANDBOX_API_BASE_URI : API_BASE_URI;
+        final String apiUri = exchangeSpecification.getStreamingUri();
 
         ProductSubscription subscriptions = args[0];
         streamingService = createStreamingService(apiUri, subscriptions);

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceStreamingMarketDataService.java
@@ -312,7 +312,7 @@ public class BinanceStreamingMarketDataService implements StreamingMarketDataSer
   }
 
   protected Flowable<OrderBook> createOrderBookFlowable(CurrencyPair currencyPair) {
-    // 1. Open a stream to wss://stream.binance.com:9443/ws/bnbbtc@depth
+    // 1. Open a stream to ${STREAMING_URI}/ws/bnbbtc@depth
     // 2. Buffer the events you receive from the stream.
     OrderbookSubscription subscription =
         new OrderbookSubscription(orderBookRawUpdatesSubscriptions.get(currencyPair));

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/BinanceUserDataStreamingService.java
@@ -14,10 +14,8 @@ public class BinanceUserDataStreamingService extends JsonNettyStreamingService {
 
   private static final Logger LOG = LoggerFactory.getLogger(BinanceUserDataStreamingService.class);
 
-  private static final String USER_API_BASE_URI = "wss://stream.binance.com:9443/ws/";
-
-  public static BinanceUserDataStreamingService create(String listenKey) {
-    return new BinanceUserDataStreamingService(USER_API_BASE_URI + listenKey);
+  public static BinanceUserDataStreamingService create(String apiUri, String listenKey) {
+    return new BinanceUserDataStreamingService(apiUri + "/ws/" + listenKey);
   }
 
   protected BinanceUserDataStreamingService(String url) {

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/futures/BinanceFuturesStreamingMarketDataService.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/futures/BinanceFuturesStreamingMarketDataService.java
@@ -77,7 +77,7 @@ public class BinanceFuturesStreamingMarketDataService extends BinanceStreamingMa
     }
 
     protected Flowable<OrderBook> createOrderBookFlowable(CurrencyPair currencyPair) {
-        // 1. Open a stream to wss://stream.binance.com:9443/ws/bnbbtc@depth
+        // 1. Open a stream to ${STREAMING_URI}/ws/bnbbtc@depth
         // 2. Buffer the events you receive from the stream.
         OrderbookSubscription subscription =
                 new OrderbookSubscription(orderBookRawUpdatesSubscriptions.get(currencyPair));

--- a/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/futures/dto/AccountUpdateBinanceWebsocketTransaction.java
+++ b/xchange-stream-binance/src/main/java/info/bitrich/xchangestream/binance/futures/dto/AccountUpdateBinanceWebsocketTransaction.java
@@ -50,18 +50,18 @@ public class AccountUpdateBinanceWebsocketTransaction
   public List<Balance> toBalanceList() {
     if (getBalances() == null) return Collections.emptyList();
     return getBalances().stream()
-        .map(
-            b ->
-                new Balance(
-                    Currency.getInstance(b.getAsset()),
-                    b.getWalletBalance(),
-                    b.getWalletBalance(),
-                    BigDecimal.ZERO,
-                    BigDecimal.ZERO,
-                    BigDecimal.ZERO,
-                    BigDecimal.ZERO,
-                    BigDecimal.ZERO,
-                    new Date(transactionTime)))
+        .map(b -> {
+          return new Balance(
+                  Currency.getInstance(b.getAsset()),
+                  b.getWalletBalance(),
+                  getAvailable(b),
+                  BigDecimal.ZERO,
+                  BigDecimal.ZERO,
+                  BigDecimal.ZERO,
+                  BigDecimal.ZERO,
+                  BigDecimal.ZERO,
+                  new Date(transactionTime));
+            })
         .collect(Collectors.toList());
   }
 
@@ -76,5 +76,10 @@ public class AccountUpdateBinanceWebsocketTransaction
                     .timestamp(new Date(transactionTime))
                     .build())
             .collect(Collectors.toList());
+  }
+
+
+  static BigDecimal getAvailable(BinanceFuturesWebsocketBalance b) {
+    return b.getBalanceChange() != null ? b.getWalletBalance().add(b.getBalanceChange()) : b.getWalletBalance();
   }
 }

--- a/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/futures/dto/AccountUpdateBinanceWebsocketTransactionTest.java
+++ b/xchange-stream-binance/src/test/java/info/bitrich/xchangestream/binance/futures/dto/AccountUpdateBinanceWebsocketTransactionTest.java
@@ -1,0 +1,21 @@
+package info.bitrich.xchangestream.binance.futures.dto;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AccountUpdateBinanceWebsocketTransactionTest {
+
+	@Test
+	public void testGetAvailable() {
+		BigDecimal value = AccountUpdateBinanceWebsocketTransaction.getAvailable(new BinanceFuturesWebsocketBalance("USD",
+				BigDecimal.TEN,
+				BigDecimal.ONE,
+				BigDecimal.ONE.negate()
+		));
+
+		assertThat(value).isEqualByComparingTo(new BigDecimal("9"));
+	}
+}


### PR DESCRIPTION
Exchange changes:
- refactor sandbox functionality - move override logics to the exchange level
- add deribit sandbox support
- add streaming uri to spec 
- refactor binance streaming static urls to fully support sandbox 

Core API changes:
- open position: add liquidation price and PNL fields
- add Margin Info to AccountInfo that holds brief margin info (currency, margin balance, pnl)
- adopt new models and updates for Ftx, Binance, Deribit
- AccountInfo.Builder

Other:
- [POM] edit list of integration tests for more accurate mvn test run
- fix Deribit API bug
- fix binance streaming adapter to respect *available* amount

Added sample tests for Ftx, Deribit