### PR TITLE
Added Deribit rate limiter support

### DIFF
--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitResilience.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/DeribitResilience.java
@@ -1,0 +1,42 @@
+package org.knowm.xchange.deribit.v2;
+
+import io.github.resilience4j.ratelimiter.RateLimiterConfig;
+import org.knowm.xchange.client.ResilienceRegistries;
+import org.knowm.xchange.client.ResilienceUtils;
+
+import java.time.Duration;
+
+import static javax.ws.rs.core.Response.Status.TOO_MANY_REQUESTS;
+
+public class DeribitResilience {
+
+    public static final String PUBLIC_REST_ENDPOINT_RATE_LIMITER = "publicEndpointLimit";
+
+    public static final String PRIVATE_REST_ENDPOINT_RATE_LIMITER = "privateEndpointLimit";
+
+    public static ResilienceRegistries createRegistries() {
+        final ResilienceRegistries registries = new ResilienceRegistries();
+
+        registries
+                .rateLimiters()
+                .rateLimiter(
+                        PUBLIC_REST_ENDPOINT_RATE_LIMITER,
+                        RateLimiterConfig.from(registries.rateLimiters().getDefaultConfig())
+                                .limitRefreshPeriod(Duration.ofSeconds(1))
+                                .limitForPeriod(20)
+                                .drainPermissionsOnResult(e -> ResilienceUtils.matchesHttpCode(e, TOO_MANY_REQUESTS))
+                                .build());
+
+        registries
+                .rateLimiters()
+                .rateLimiter(
+                        PRIVATE_REST_ENDPOINT_RATE_LIMITER,
+                        RateLimiterConfig.from(registries.rateLimiters().getDefaultConfig())
+                                .limitRefreshPeriod(Duration.ofSeconds(1))
+                                .limitForPeriod(30)
+                                .drainPermissionsOnResult(e -> ResilienceUtils.matchesHttpCode(e, TOO_MANY_REQUESTS))
+                                .build());
+
+        return registries;
+    }
+}

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitAccountService.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitAccountService.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.deribit.v2.service;
 import java.io.IOException;
 import java.util.*;
 
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.deribit.v2.DeribitAdapters;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
@@ -12,8 +13,9 @@ import org.knowm.xchange.service.account.AccountService;
 
 public class DeribitAccountService extends DeribitAccountServiceRaw implements AccountService {
 
-  public DeribitAccountService(DeribitExchange exchange) {
-    super(exchange);
+  public DeribitAccountService(DeribitExchange exchange,
+                               ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   @Override

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitAccountServiceRaw.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitAccountServiceRaw.java
@@ -2,22 +2,31 @@ package org.knowm.xchange.deribit.v2.service;
 
 import java.io.IOException;
 import java.util.List;
+
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.Kind;
 import org.knowm.xchange.deribit.v2.dto.account.AccountSummary;
 import org.knowm.xchange.deribit.v2.dto.account.Position;
 
+import static org.knowm.xchange.deribit.v2.DeribitResilience.PRIVATE_REST_ENDPOINT_RATE_LIMITER;
+
 public class DeribitAccountServiceRaw extends DeribitBaseService {
 
-  public DeribitAccountServiceRaw(DeribitExchange exchange) {
-    super(exchange);
+  public DeribitAccountServiceRaw(DeribitExchange exchange,
+                                  ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   public AccountSummary getAccountSummary(String currency, Boolean extended) throws IOException {
-    return deribitAuthenticated.getAccountSummary(currency, extended, deribitAuth).getResult();
+    return decorateApiCall(() -> deribitAuthenticated.getAccountSummary(currency, extended, deribitAuth).getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<Position> getPositions(String currency, Kind kind) throws IOException {
-    return deribitAuthenticated.getPositions(currency, kind, deribitAuth).getResult();
+    return decorateApiCall(() -> deribitAuthenticated.getPositions(currency, kind, deribitAuth).getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 }

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitBaseService.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitBaseService.java
@@ -8,6 +8,7 @@ import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.Getter;
 import org.knowm.xchange.client.ExchangeRestProxyBuilder;
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.deribit.v2.Deribit;
 import org.knowm.xchange.deribit.v2.DeribitAuthenticated;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
@@ -16,13 +17,13 @@ import org.knowm.xchange.deribit.v2.dto.GrantType;
 import org.knowm.xchange.deribit.v2.dto.account.DeribitAuthentication;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.ExchangeSecurityException;
-import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseParamsDigest;
+import org.knowm.xchange.service.BaseResilientExchangeService;
 import org.knowm.xchange.service.BaseService;
 import org.knowm.xchange.utils.DigestUtils;
 import si.mazi.rescu.ParamsDigest;
 
-public class DeribitBaseService extends BaseExchangeService<DeribitExchange>
+public class DeribitBaseService extends BaseResilientExchangeService<DeribitExchange>
     implements BaseService {
 
   protected final Deribit deribit;
@@ -35,9 +36,9 @@ public class DeribitBaseService extends BaseExchangeService<DeribitExchange>
    *
    * @param exchange
    */
-  public DeribitBaseService(DeribitExchange exchange) {
-
-    super(exchange);
+  public DeribitBaseService(DeribitExchange exchange,
+                            ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
     deribit =
         ExchangeRestProxyBuilder.forInterface(Deribit.class, exchange.getExchangeSpecification())
             .build();

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitMarketDataService.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitMarketDataService.java
@@ -1,6 +1,8 @@
 package org.knowm.xchange.deribit.v2.service;
 
 import java.io.IOException;
+
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.deribit.v2.DeribitAdapters;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.DeribitException;
@@ -29,9 +31,9 @@ public class DeribitMarketDataService extends DeribitMarketDataServiceRaw
    *
    * @param exchange
    */
-  public DeribitMarketDataService(DeribitExchange exchange) {
-
-    super(exchange);
+  public DeribitMarketDataService(DeribitExchange exchange,
+                                  ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   @Override

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitMarketDataServiceRaw.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitMarketDataServiceRaw.java
@@ -2,6 +2,8 @@ package org.knowm.xchange.deribit.v2.service;
 
 import java.io.IOException;
 import java.util.List;
+
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.Kind;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitCurrency;
@@ -10,6 +12,8 @@ import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitOrderBook;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitSummary;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitTicker;
 import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitTrades;
+
+import static org.knowm.xchange.deribit.v2.DeribitResilience.PUBLIC_REST_ENDPOINT_RATE_LIMITER;
 
 /**
  * Implementation of the market data service for Deribit
@@ -20,22 +24,29 @@ import org.knowm.xchange.deribit.v2.dto.marketdata.DeribitTrades;
  */
 public class DeribitMarketDataServiceRaw extends DeribitBaseService {
 
-  public DeribitMarketDataServiceRaw(DeribitExchange exchange) {
-    super(exchange);
+  public DeribitMarketDataServiceRaw(DeribitExchange exchange,
+                                     ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   public List<DeribitInstrument> getDeribitInstruments(String currency, Kind kind, Boolean expired)
       throws IOException {
-    return deribit.getInstruments(currency, kind, expired).getResult();
+    return decorateApiCall(() -> deribit.getInstruments(currency, kind, expired).getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<DeribitCurrency> getDeribitCurrencies() throws IOException {
-    return deribit.getCurrencies().getResult();
+    return decorateApiCall(() -> deribit.getCurrencies().getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public DeribitOrderBook getDeribitOrderBook(String instrumentName, Integer depth)
       throws IOException {
-    return deribit.getOrderBook(instrumentName, depth).getResult();
+    return decorateApiCall(() -> deribit.getOrderBook(instrumentName, depth).getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public DeribitTrades getLastTradesByInstrument(
@@ -46,16 +57,22 @@ public class DeribitMarketDataServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       String sorting)
       throws IOException {
-    return deribit
+    return decorateApiCall(() -> deribit
         .getLastTradesByInstrument(instrumentName, startSeq, endSeq, count, includeOld, sorting)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<DeribitSummary> getSummaryByInstrument(String instrumentName) throws IOException {
-    return deribit.getSummaryByInstrument(instrumentName).getResult();
+    return decorateApiCall(() -> deribit.getSummaryByInstrument(instrumentName).getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public DeribitTicker getDeribitTicker(String instrumentName) throws IOException {
-    return deribit.getTicker(instrumentName).getResult();
+    return decorateApiCall(() -> deribit.getTicker(instrumentName).getResult())
+            .withRateLimiter(rateLimiter(PUBLIC_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 }

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitTradeService.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitTradeService.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.deribit.v2.DeribitAdapters;
@@ -27,8 +29,9 @@ import org.knowm.xchange.service.trade.params.orders.*;
 
 public class DeribitTradeService extends DeribitTradeServiceRaw implements TradeService {
 
-  public DeribitTradeService(DeribitExchange exchange) {
-    super(exchange);
+  public DeribitTradeService(DeribitExchange exchange,
+                             ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   @Override

--- a/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitTradeServiceRaw.java
+++ b/xchange-deribit/src/main/java/org/knowm/xchange/deribit/v2/service/DeribitTradeServiceRaw.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+
+import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.deribit.v2.DeribitExchange;
 import org.knowm.xchange.deribit.v2.dto.Kind;
 import org.knowm.xchange.deribit.v2.dto.trade.AdvancedOptions;
@@ -16,10 +18,13 @@ import org.knowm.xchange.deribit.v2.dto.trade.Trigger;
 import org.knowm.xchange.deribit.v2.dto.trade.UserSettlements;
 import org.knowm.xchange.deribit.v2.dto.trade.UserTrades;
 
+import static org.knowm.xchange.deribit.v2.DeribitResilience.PRIVATE_REST_ENDPOINT_RATE_LIMITER;
+
 public class DeribitTradeServiceRaw extends DeribitBaseService {
 
-  public DeribitTradeServiceRaw(DeribitExchange exchange) {
-    super(exchange);
+  public DeribitTradeServiceRaw(DeribitExchange exchange,
+                                ResilienceRegistries resilienceRegistries) {
+    super(exchange, resilienceRegistries);
   }
 
   public OrderPlacement buy(
@@ -38,7 +43,7 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       AdvancedOptions advanced,
       Boolean mmp)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .buy(
             instrumentName,
             amount,
@@ -55,7 +60,9 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
             advanced,
             mmp,
             deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public OrderPlacement sell(
@@ -74,7 +81,7 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       AdvancedOptions advanced,
       Boolean mmp)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .sell(
             instrumentName,
             amount,
@@ -91,7 +98,9 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
             advanced,
             mmp,
             deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public OrderPlacement edit(
@@ -105,7 +114,7 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       AdvancedOptions advanced,
       Boolean mmp)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .edit(
             orderId,
             amount,
@@ -117,29 +126,39 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
             advanced,
             mmp,
             deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public Order cancel(String orderId) throws IOException {
-    return deribitAuthenticated.cancel(orderId, deribitAuth).getResult();
+    return decorateApiCall(() -> deribitAuthenticated.cancel(orderId, deribitAuth).getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public Integer cancelByLabel(String label) throws IOException {
-    return deribitAuthenticated.cancelByLabel(label, deribitAuth).getResult();
+    return decorateApiCall(() -> deribitAuthenticated.cancelByLabel(label, deribitAuth).getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<Order> getOpenOrdersByCurrency(String currency, Kind kind, String type)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getOpenOrdersByCurrency(currency, kind, type, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<Order> getOpenOrdersByInstrument(String instrumentName, String type)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getOpenOrdersByInstrument(instrumentName, type, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public UserTrades getUserTradesByCurrency(
@@ -151,10 +170,12 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       String sorting)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getUserTradesByCurrency(
             currency, kind, startId, endId, count, includeOld, sorting, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public UserTrades getUserTradesByCurrencyAndTime(
@@ -166,7 +187,7 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       String sorting)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getUserTradesByCurrencyAndTime(
             currency,
             kind,
@@ -176,7 +197,9 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
             includeOld,
             sorting,
             deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public UserTrades getUserTradesByInstrument(
@@ -187,10 +210,12 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       String sorting)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getUserTradesByInstrument(
             instrumentName, startSeq, endSeq, count, includeOld, sorting, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public UserTrades getUserTradesByInstrumentAndTime(
@@ -201,7 +226,7 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       String sorting)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getUserTradesByInstrumentAndTime(
             instrumentName,
             startTimestamp.getTime(),
@@ -210,15 +235,19 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
             includeOld,
             sorting,
             deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public UserSettlements getUserSettlementsByInstrument(
       String instrumentName, SettlementType type, Integer count, String continuation)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getSettlementHistoryByInstrument(instrumentName, type, count, continuation, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<Order> getOrderHistoryByCurrency(
@@ -229,10 +258,12 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       Boolean includeUnfilled)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getOrderHistoryByCurrency(
             currency, kind, count, offset, includeOld, includeUnfilled, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public List<Order> getOrderHistoryByInstrument(
@@ -242,13 +273,17 @@ public class DeribitTradeServiceRaw extends DeribitBaseService {
       Boolean includeOld,
       Boolean includeUnfilled)
       throws IOException {
-    return deribitAuthenticated
+    return decorateApiCall(() -> deribitAuthenticated
         .getOrderHistoryByInstrument(
             instrumentName, count, offset, includeOld, includeUnfilled, deribitAuth)
-        .getResult();
+        .getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 
   public Order getOrderState(String orderId) throws IOException {
-    return deribitAuthenticated.getOrderState(orderId, deribitAuth).getResult();
+    return decorateApiCall(() -> deribitAuthenticated.getOrderState(orderId, deribitAuth).getResult())
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call();
   }
 }


### PR DESCRIPTION
In according to https://legacy.deribit.com/pages/information/rate-limits two rate limiters where added:
1. 20 requests per second for public calls
2. 30 requests per second for private calls 